### PR TITLE
Ignore .DS_Store files when parsing blocks

### DIFF
--- a/pages/browser.js
+++ b/pages/browser.js
@@ -69,7 +69,7 @@ export async function getServerSideProps({ req }) {
       const { name: block } = entry
       props.blocks[block] = {}
       const presets = await rd(`${hr}/Blocks/${block}`, {withFileTypes: true})
-      for (const pEntry of presets.filter(p => p.isDirectory)) {
+      for (const pEntry of presets.filter(p => p.isDirectory && p.name !== '.DS_Store')) {
         const {name: preset} = pEntry
         const stream = await rf(`${hr}/Blocks/${block}/${preset}`)
         const json = JSON.parse(stream) || {}


### PR DESCRIPTION
Make sure to avoid those pesky `.DS_Store` files on the Mac...